### PR TITLE
add presentedChild

### DIFF
--- a/Examples/05_Present/PresentDetail/PresentDetailReducer.swift
+++ b/Examples/05_Present/PresentDetail/PresentDetailReducer.swift
@@ -15,7 +15,7 @@ struct PresentDetailReducer {
             case .noData:
                 return .none
             case .data:
-                return .dismiss
+                return .dismiss(all: false)
             }
         }
     })

--- a/Sources/LBPresenter/Effect.swift
+++ b/Sources/LBPresenter/Effect.swift
@@ -37,7 +37,7 @@ public enum Effect<Action, NavigationAction> {
         cancelId: String? = nil
     )
 
-    case dismiss
+    case dismiss(all: Bool)
 
     /// Cancels an ongoing side effect associated with a specific `cancelId`.
     ///

--- a/Sources/LBPresenter/Protocols/LBSheetPresenter.swift
+++ b/Sources/LBPresenter/Protocols/LBSheetPresenter.swift
@@ -9,5 +9,7 @@ import Foundation
 
 @MainActor
 protocol LBSheetPresenter {
+    var presentedChild: (any LBPresenterProtocol)? { get set }
     func dismiss()
+    func dismissAll()
 }


### PR DESCRIPTION
Dans le cas où on present plusieurs sheet les unes sur les autres, quand on appelle l'effect dismiss, ça dismiss toutes les sheet et pas seulement la dernière. 
J'ai différencié le dismissAll et le dismiss en ajoutant un presentedChild dans le présenter. Ça permet de savoir si on est le parent direct et qu'on arrête d'appeler les dismiss des parents.
Je ne comprenais pas trop comment était retenu le @ObservedObject du presenter enfant. Maintenant il est retenu par le presenter parent, ce qui corrigera peut être le souci de reset du presenter quand on passe de lightMode à DarkMode -> à valider dans FP.