### PR TITLE
remove child presenter in state update

### DIFF
--- a/Sources/LBPresenter/LBPresenter.swift
+++ b/Sources/LBPresenter/LBPresenter.swift
@@ -42,6 +42,10 @@ public final class LBPresenter<State: Actionnable, NavState: NavPresenterState>:
     /// Modifications to the state are restricted to the presenter logic via the reducer.
     public private(set) var state: State {
         willSet {
+            // In order to manage presentedChild removal, on interactive dismiss gesture
+            if let presenterState = newValue as? any SheetPresenterState, presenterState.presented == nil {
+                self.presentedChild = nil
+            }
             // Notify subscribers only when the new value differs from the old value.
             objectWillChange.send(with: newValue, oldValue: state)
         }
@@ -265,7 +269,6 @@ public final class LBPresenter<State: Actionnable, NavState: NavPresenterState>:
             sheetParent.dismiss()
         } else {
             state.dismiss()
-            presentedChild = nil
         }
     }
 }


### PR DESCRIPTION
Si on fait un dismiss en swipant vers le bas, on ne passe pas dans la fonction dismiss qui clean le presentedChild. Du coup si on veut présenter un autre écran, on réaffiche le même que précédemment.
En remettant à nil le presentedChild lors du changement de state, on sait qu'on le fait dans tous les cas. J'ai bien testé, j'espère qu'il n'y a pas d'effets de bord...